### PR TITLE
deps: Bump token-2022 and token-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6941,9 +6941,9 @@ dependencies = [
 
 [[package]]
 name = "spl-elgamal-registry"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65edfeed09cd4231e595616aa96022214f9c9d2be02dea62c2b30d5695a6833a"
+checksum = "56cc66fe64651a48c8deb4793d8a5deec8f8faf19f355b9df294387bc5a36b5f"
 dependencies = [
  "bytemuck",
  "solana-account-info",
@@ -6955,11 +6955,12 @@ dependencies = [
  "solana-pubkey",
  "solana-rent",
  "solana-sdk-ids",
+ "solana-security-txt",
  "solana-system-interface",
  "solana-sysvar",
  "solana-zk-sdk",
  "spl-pod",
- "spl-token-confidential-transfer-proof-extraction 0.3.0",
+ "spl-token-confidential-transfer-proof-extraction 0.4.0",
 ]
 
 [[package]]
@@ -7214,9 +7215,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "8.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f0dfbb079eebaee55e793e92ca5f433744f4b71ee04880bfd6beefba5973e5"
+checksum = "707d8237d17d857246b189d0fb278797dcd7cf6219374547791b231fd35a8cc8"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -7242,12 +7243,12 @@ dependencies = [
  "solana-system-interface",
  "solana-sysvar",
  "solana-zk-sdk",
- "spl-elgamal-registry 0.2.0",
+ "spl-elgamal-registry 0.3.0",
  "spl-memo",
  "spl-pod",
  "spl-token 8.0.0",
  "spl-token-confidential-transfer-ciphertext-arithmetic 0.3.0",
- "spl-token-confidential-transfer-proof-extraction 0.3.0",
+ "spl-token-confidential-transfer-proof-extraction 0.4.0",
  "spl-token-confidential-transfer-proof-generation 0.4.0",
  "spl-token-group-interface 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-metadata-interface 0.7.0",
@@ -7258,9 +7259,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110082393ab2f9129e23a58c7cdd94f751096937ba190110a7f0d6e8685dcb63"
+checksum = "4c063f31347dec4286beec6e568c70059d27295c1b013711c26c84d52a60a1e7"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7274,12 +7275,12 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-sdk",
  "spl-associated-token-account-client",
- "spl-elgamal-registry 0.2.0",
+ "spl-elgamal-registry 0.3.0",
  "spl-memo",
  "spl-record",
  "spl-token 8.0.0",
- "spl-token-2022 8.0.1",
- "spl-token-confidential-transfer-proof-extraction 0.3.0",
+ "spl-token-2022 9.0.0",
+ "spl-token-confidential-transfer-proof-extraction 0.4.0",
  "spl-token-confidential-transfer-proof-generation 0.4.0",
  "spl-token-group-interface 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-metadata-interface 0.7.0",
@@ -7327,9 +7328,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2629860ff04c17bafa9ba4bed8850a404ecac81074113e1f840dbd0ebb7bd6"
+checksum = "bedc4675c80409a004da46978674e4073c65c4b1c611bf33d120381edeffe036"
 dependencies = [
  "bytemuck",
  "solana-account-info",
@@ -7387,7 +7388,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator",
  "spl-pod",
- "spl-token-2022 8.0.1",
+ "spl-token-2022 9.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.6.0",
  "spl-token-metadata-interface 0.7.0",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -16,7 +16,7 @@ test-sbf = []
 [dependencies]
 solana-program = "2.2.1"
 spl-pod = "0.5.1"
-spl-token-2022 = { version = "8.0.1", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "9.0.0", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.6.0", path = "../interface" }
 spl-type-length-value = "0.8.0"
 
@@ -24,7 +24,7 @@ spl-type-length-value = "0.8.0"
 solana-program-test = "2.2.0"
 solana-sdk = "2.2.1"
 spl-discriminator = "0.4.0"
-spl-token-client = "0.15.0"
+spl-token-client = "0.16.0"
 spl-token-metadata-interface = "0.7.0"
 
 [lib]


### PR DESCRIPTION
#### Problem

token-2022 and token-client need to be bumped together, but dependabot does them at the same time, causing failures.

#### Summary of changes

Bump them both