### PR TITLE
CI: Pin cargo-release and cargo-semver-checks

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-semver-checks,cargo-release
+          tool: cargo-semver-checks@0.42.0,cargo-release@0.25.18
 
       - name: Set Git Author (required for cargo-release)
         run: |
@@ -129,7 +129,7 @@ jobs:
       - name: Install cargo-release
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-release
+          tool: cargo-release@0.25.18
 
       - name: Ensure CARGO_REGISTRY_TOKEN variable is set
         env:


### PR DESCRIPTION
#### Problem

The release job is failing because it can't install cargo-semver-checks due to the lower Rust version declared in the repo.

Also, cargo-release just bumped up to 1.87 on master, which means that a release with a higher MSRV is just around the corner.

#### Summary of changes

Pin the versions of both tools to the latest that supports Rust 1.86.