### PR TITLE
interface: Don't mark as cdylib

### DIFF
--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -26,7 +26,7 @@ solana-sha256-hasher = "3.0.0"
 spl-type-length-value = { version = "0.9.0", features = ["derive"] }
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
#### Problem

The interface crate is marked with `cdylib`, which makes it impossible to run LTO with the rust compiler. Since it isn't a program, it doesn't need to have the cdylib target.

#### Summary of changes

Remove the cdylib target.