### PR TITLE
build(js-legacy): upgrade TypeScript to 6.0

### DIFF
--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -72,7 +72,7 @@
         "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
         "typedoc": "^0.28.19",
-        "typescript": "^5.7.2"
+        "typescript": "^6.0.3"
     },
     "prettier": "@solana/prettier-config-solana"
 }

--- a/clients/js-legacy/tsconfig.base.json
+++ b/clients/js-legacy/tsconfig.base.json
@@ -9,6 +9,8 @@
         "noEmitOnError": true,
         "resolveJsonModule": true,
         "strict": true,
-        "stripInternal": true
+        "stripInternal": true,
+        "ignoreDeprecations": "6.0",
+        "types": ["node"]
     }
 }

--- a/clients/js-legacy/tsconfig.cjs.json
+++ b/clients/js-legacy/tsconfig.cjs.json
@@ -5,6 +5,7 @@
         "outDir": "dist/cjs",
         "target": "ES2016",
         "module": "CommonJS",
-        "sourceMap": true
+        "sourceMap": true,
+        "rootDir": "./src"
     }
 }

--- a/clients/js-legacy/tsconfig.esm.json
+++ b/clients/js-legacy/tsconfig.esm.json
@@ -8,6 +8,7 @@
         "module": "ES2020",
         "sourceMap": true,
         "declaration": true,
-        "declarationMap": true
+        "declarationMap": true,
+        "rootDir": "./src"
     }
 }

--- a/clients/js-legacy/tsconfig.json
+++ b/clients/js-legacy/tsconfig.json
@@ -3,6 +3,7 @@
     "include": ["src", "test"],
     "compilerOptions": {
         "noEmit": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "types": ["node", "mocha"]
     }
 }


### PR DESCRIPTION
Upgrades the `clients/js-legacy` client to TypeScript 6.0. This client uses the `tsc --build` (project references) setup, so the changes differ from the modern `clients/js` clients.

## Changes
- Bump `typescript` `^5.7.2` → `^6.0.3`.
- `tsconfig.base.json`: add `"ignoreDeprecations": "6.0"` and `"types": ["node"]`.
- `tsconfig.cjs.json` / `tsconfig.esm.json`: add `"rootDir": "./src"`.
- `tsconfig.json`: set `"types": ["node", "mocha"]`.

## Why each change (the actual TS6 breaks)
Building unmodified under `typescript@6.0.3` fails with:
- **TS5107** — `node10`/`"Node"` module resolution is deprecated → `ignoreDeprecations: "6.0"`.
- **TS5011** — the `cjs`/`esm` composite projects need an explicit `rootDir` → `rootDir: "./src"`.
- **TS2591** — `Buffer`/`http`/`https` globals can't be found (`@types/node@26` doesn't auto-resolve under the classic resolver) → `types: ["node"]` in the base.

Narrowing the base `types` to `["node"]` then hides mocha's globals from the test build, so `tsconfig.json` (which includes `test`) re-adds `["node", "mocha"]`.

Module resolution is intentionally **left as `Node`** and **no `lib` override** is added — only the options TS6 actually requires were touched.

## Verification
Locally with `typescript@6.0.3`:
- ✅ `pnpm build` (`tsc --build tsconfig.all.json`) — cjs/esm/types all emit
- ✅ `pnpm lint` (eslint, clean tree) — clean
- ✅ `pnpm test` (mocha) — **7 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)